### PR TITLE
Add an option to run geth in Thunder mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,5 +26,6 @@ jobs:
     steps:
       - checkout
 
+      - setup_remote_docker
       # specify any bash command here prefixed with `run: `
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # with Go source code. If you know what GOPATH is then you probably
 # don't need to bother with make.
 
-.PHONY: geth android ios geth-cross swarm evm all test clean
+.PHONY: base geth thunder android ios geth-cross swarm evm all test clean
 .PHONY: geth-linux geth-linux-386 geth-linux-amd64 geth-linux-mips64 geth-linux-mips64le
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
@@ -11,10 +11,16 @@
 GOBIN = $(shell pwd)/build/bin
 GO ?= latest
 
-geth:
+base:
 	build/env.sh go run build/ci.go install ./cmd/geth
 	@echo "Done building."
+
+geth: base
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
+
+thunder: base
+	@cd $(GOBIN) && ln -sf geth thunderlocal
+	@echo "Run \"$(GOBIN)/thunderlocal\" to launch thunder local chain."
 
 swarm:
 	build/env.sh go run build/ci.go install ./cmd/swarm
@@ -23,6 +29,7 @@ swarm:
 
 all:
 	build/env.sh go run build/ci.go install
+	@cd $(GOBIN) && ln -sf geth thunderlocal
 
 android:
 	build/env.sh go run build/ci.go aar --local

--- a/README.md
+++ b/README.md
@@ -1,311 +1,194 @@
-## Go Ethereum
-
-Official golang implementation of the Ethereum protocol.
+## Thunder Local Chain
 
-[![API Reference](
-https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
-)](https://godoc.org/github.com/ethereum/go-ethereum)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ethereum/go-ethereum)](https://goreportcard.com/report/github.com/ethereum/go-ethereum)
-[![Travis](https://travis-ci.org/ethereum/go-ethereum.svg?branch=master)](https://travis-ci.org/ethereum/go-ethereum)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereum/go-ethereum?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+For original Ethereum readme, please [check here](README_ETH.md)
 
-Automated builds are available for stable releases and the unstable master branch.
-Binary archives are published at https://geth.ethereum.org/downloads/.
+## Building from source
 
-## Building the source
+Clone the repository to a directory on your local,
 
-For prerequisites and detailed build instructions please read the
-[Installation Instructions](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum)
-on the wiki.
+    # git clone https://github.com/thundercore/go-ethereum.git
 
-Building geth requires both a Go (version 1.7 or later) and a C compiler.
-You can install them using your favourite package manager.
-Once the dependencies are installed, run
+Make sure you have Go compiler installed,
 
-    make geth
+on mac,
 
-or, to build the full suite of utilities:
+    # brew install go
 
-    make all
+on Ubuntu,
 
-## Executables
+    # sudo apt-get install -y build-essential golang
 
-The go-ethereum project comes with several wrappers/executables found in the `cmd` directory.
+on Fedora,
 
-| Command    | Description |
-|:----------:|-------------|
-| **`geth`** | Our main Ethereum CLI client. It is the entry point into the Ethereum network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It can be used by other processes as a gateway into the Ethereum network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI Wiki page](https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options) for command line options. |
-| `abigen` | Source code generator to convert Ethereum contract definitions into easy to use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI) with expanded functionality if the contract bytecode is also available. However it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://github.com/ethereum/go-ethereum/wiki/Native-DApps:-Go-bindings-to-Ethereum-contracts) wiki page for details. |
-| `bootnode` | Stripped down version of our Ethereum client implementation that only takes part in the network node discovery protocol, but does not run any of the higher level application protocols. It can be used as a lightweight bootstrap node to aid in finding peers in private networks. |
-| `evm` | Developer utility version of the EVM (Ethereum Virtual Machine) that is capable of running bytecode snippets within a configurable environment and execution mode. Its purpose is to allow isolated, fine-grained debugging of EVM opcodes (e.g. `evm --code 60ff60ff --debug`). |
-| `gethrpctest` | Developer utility tool to support our [ethereum/rpc-test](https://github.com/ethereum/rpc-tests) test suite which validates baseline conformity to the [Ethereum JSON RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC) specs. Please see the [test suite's readme](https://github.com/ethereum/rpc-tests/blob/master/README.md) for details. |
-| `rlpdump` | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://github.com/ethereum/wiki/wiki/RLP)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`). |
-| `swarm`    | Swarm daemon and tools. This is the entrypoint for the Swarm network. `swarm --help` for command line options and subcommands. See [Swarm README](https://github.com/ethereum/go-ethereum/tree/master/swarm) for more information. |
-| `puppeth`    | a CLI wizard that aids in creating a new Ethereum network. |
+    # sudo dnf install -y golang
 
-## Running geth
+Build the local chain binary,
 
-Going through all the possible command line flags is out of scope here (please consult our
-[CLI Wiki page](https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options)), but we've
-enumerated a few common parameter combos to get you up to speed quickly on how you can run your
-own Geth instance.
+    # make thunder
 
-### Full node on the main Ethereum network
+Build the whole suite,
 
-By far the most common scenario is people wanting to simply interact with the Ethereum network:
-create accounts; transfer funds; deploy and interact with contracts. For this particular use-case
-the user doesn't care about years-old historical data, so we can fast-sync quickly to the current
-state of the network. To do so:
+    # make all
 
-```
-$ geth console
-```
+## Start local chain
 
-This command will:
+### Create an account
+Find a folder and run "thunderlocal account new " from shell and set a password when asked,
 
- * Start geth in fast sync mode (default, can be changed with the `--syncmode` flag), causing it to
-   download more data in exchange for avoiding processing the entire history of the Ethereum network,
-   which is very CPU intensive.
- * Start up Geth's built-in interactive [JavaScript console](https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console),
-   (via the trailing `console` subcommand) through which you can invoke all official [`web3` methods](https://github.com/ethereum/wiki/wiki/JavaScript-API)
-   as well as Geth's own [management APIs](https://github.com/ethereum/go-ethereum/wiki/Management-APIs).
-   This tool is optional and if you leave it out you can always attach to an already running Geth instance
-   with `geth attach`.
+    # thunderlocal account new --datadir ./datadir
+    Your new account is locked with a password. Please give a password. Do not forget this password.
+    Passphrase:
+    Repeat passphrase:
+    Address: {0af454242c456d1fc25c1d74a56a00a816ec336b}
 
-### Full node on the Ethereum test network
+This command will create an account and account information is saved in ./datadir/keystore/UTC--XXX
 
-Transitioning towards developers, if you'd like to play around with creating Ethereum contracts, you
-almost certainly would like to do that without any real money involved until you get the hang of the
-entire system. In other words, instead of attaching to the main network, you want to join the **test**
-network with your node, which is fully equivalent to the main network, but with play-Ether only.
+### Create a genesis json file
+We can prefund the account created above. Please note the "alloc" block. And name the file as, for example thunder.json
 
-```
-$ geth --testnet console
-```
+    {
+        "config": {
+            "chainId": 3606,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip155Block": 0,
+            "eip158Block": 0,
+            "byzantiumBlock": 0,
+            "thunder": {
+            }
+        },
+        "nonce": "0x0",
+        "gasLimit": "0x989680",
+        "difficulty": "0x1",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "coinbase": "0x0000000000000000000000000000000000000000",
+        "alloc": {
+            "0x0af454242c456d1fc25c1d74a56a00a816ec336b" : { "balance": "1000000000000000000000000000000000000000" }
+        },
+        "number": "0x0",
+        "gasUsed": "0x0",
+        "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    }
 
-The `console` subcommand have the exact same meaning as above and they are equally useful on the
-testnet too. Please see above for their explanations if you've skipped to here.
+Please note the "thunder" block in the json file, which will use thunder consensus engine when starting a local chain. Alternatively, we can also create such genesis json file by [using setup wizard, puppeth](#puppeth).
 
-Specifying the `--testnet` flag however will reconfigure your Geth instance a bit:
+### <a name="initchain"></a>Initialize the chain
 
- * Instead of using the default data directory (`~/.ethereum` on Linux for example), Geth will nest
-   itself one level deeper into a `testnet` subfolder (`~/.ethereum/testnet` on Linux). Note, on OSX
-   and Linux this also means that attaching to a running testnet node requires the use of a custom
-   endpoint since `geth attach` will try to attach to a production node endpoint by default. E.g.
-   `geth attach <datadir>/testnet/geth.ipc`. Windows users are not affected by this.
- * Instead of connecting the main Ethereum network, the client will connect to the test network,
-   which uses different P2P bootnodes, different network IDs and genesis states.
-   
-*Note: Although there are some internal protective measures to prevent transactions from crossing
-over between the main network and test network, you should make sure to always use separate accounts
-for play-money and real-money. Unless you manually move accounts, Geth will by default correctly
-separate the two networks and will not make any accounts available between them.*
+    # thunderlocal init thunder.json --datadir ./datadir
 
-### Full node on the Rinkeby test network
+### Start the chain
 
-The above test network is a cross client one based on the ethash proof-of-work consensus algorithm. As such, it has certain extra overhead and is more susceptible to reorganization attacks due to the network's low difficulty / security. Go Ethereum also supports connecting to a proof-of-authority based test network called [*Rinkeby*](https://www.rinkeby.io) (operated by members of the community). This network is lighter, more secure, but is only supported by go-ethereum.
-
-```
-$ geth --rinkeby console
-```
-
-### Configuration
-
-As an alternative to passing the numerous flags to the `geth` binary, you can also pass a configuration file via:
-
-```
-$ geth --config /path/to/your_config.toml
-```
-
-To get an idea how the file should look like you can use the `dumpconfig` subcommand to export your existing configuration:
-
-```
-$ geth --your-favourite-flags dumpconfig
-```
-
-*Note: This works only with geth v1.6.0 and above.*
-
-#### Docker quick start
-
-One of the quickest ways to get Ethereum up and running on your machine is by using Docker:
-
-```
-docker run -d --name ethereum-node -v /Users/alice/ethereum:/root \
-           -p 8545:8545 -p 30303:30303 \
-           ethereum/client-go
-```
-
-This will start geth in fast-sync mode with a DB memory allowance of 1GB just as the above command does.  It will also create a persistent volume in your home directory for saving your blockchain as well as map the default ports. There is also an `alpine` tag available for a slim version of the image.
-
-Do not forget `--rpcaddr 0.0.0.0`, if you want to access RPC from other containers and/or hosts. By default, `geth` binds to the local interface and RPC endpoints is not accessible from the outside.
-
-### Programatically interfacing Geth nodes
-
-As a developer, sooner rather than later you'll want to start interacting with Geth and the Ethereum
-network via your own programs and not manually through the console. To aid this, Geth has built-in
-support for a JSON-RPC based APIs ([standard APIs](https://github.com/ethereum/wiki/wiki/JSON-RPC) and
-[Geth specific APIs](https://github.com/ethereum/go-ethereum/wiki/Management-APIs)). These can be
-exposed via HTTP, WebSockets and IPC (unix sockets on unix based platforms, and named pipes on Windows).
+    # thunderlocal --datadir ./datadir  --networkid 3606 --rpc --rpcport "8545" --rpccorsdomain "*" --rpcapi "db,eth,net,miner,web3,personal" --nodiscover  --mine
 
-The IPC interface is enabled by default and exposes all the APIs supported by Geth, whereas the HTTP
-and WS interfaces need to manually be enabled and only expose a subset of APIs due to security reasons.
-These can be turned on/off and configured as you'd expect.
+Now, you are good to go. Try to send some transactions or deploy smart contract.
 
-HTTP based JSON-RPC API options:
-
-  * `--rpc` Enable the HTTP-RPC server
-  * `--rpcaddr` HTTP-RPC server listening interface (default: "localhost")
-  * `--rpcport` HTTP-RPC server listening port (default: 8545)
-  * `--rpcapi` API's offered over the HTTP-RPC interface (default: "eth,net,web3")
-  * `--rpccorsdomain` Comma separated list of domains from which to accept cross origin requests (browser enforced)
-  * `--ws` Enable the WS-RPC server
-  * `--wsaddr` WS-RPC server listening interface (default: "localhost")
-  * `--wsport` WS-RPC server listening port (default: 8546)
-  * `--wsapi` API's offered over the WS-RPC interface (default: "eth,net,web3")
-  * `--wsorigins` Origins from which to accept websockets requests
-  * `--ipcdisable` Disable the IPC-RPC server
-  * `--ipcapi` API's offered over the IPC-RPC interface (default: "admin,debug,eth,miner,net,personal,shh,txpool,web3")
-  * `--ipcpath` Filename for IPC socket/pipe within the datadir (explicit paths escape it)
+### Interactive Javascript console
 
-You'll need to use your own programming environments' capabilities (libraries, tools, etc) to connect
-via HTTP, WS or IPC to a Geth node configured with the above flags and you'll need to speak [JSON-RPC](http://www.jsonrpc.org/specification)
-on all transports. You can reuse the same connection for multiple requests!
+    # thunderlocal attach http://127.0.0.1:8545
 
-**Note: Please understand the security implications of opening up an HTTP/WS based transport before
-doing so! Hackers on the internet are actively trying to subvert Ethereum nodes with exposed APIs!
-Further, all browser tabs can access locally running webservers, so malicious webpages could try to
-subvert locally available APIs!**
-
-### Operating a private network
+### <a name="puppeth"></a>Use puppeth to initialize genesis json config
 
-Maintaining your own private network is more involved as a lot of configurations taken for granted in
-the official networks need to be manually set up.
+"puppeth" is built when you build the whole suite by running "make all". Start the wizard from command line,
 
-#### Defining the private genesis state
+    # puppeth
 
-First, you'll need to create the genesis state of your networks, which all nodes need to be aware of
-and agree upon. This consists of a small JSON file (e.g. call it `genesis.json`):
+    Please specify a network name to administer (no spaces or hyphens, please)
+    > thunder
 
-```json
-{
-  "config": {
-        "chainId": 0,
-        "homesteadBlock": 0,
-        "eip155Block": 0,
-        "eip158Block": 0
-    },
-  "alloc"      : {},
-  "coinbase"   : "0x0000000000000000000000000000000000000000",
-  "difficulty" : "0x20000",
-  "extraData"  : "",
-  "gasLimit"   : "0x2fefd8",
-  "nonce"      : "0x0000000000000042",
-  "mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "timestamp"  : "0x00"
-}
-```
-
-The above fields should be fine for most purposes, although we'd recommend changing the `nonce` to
-some random value so you prevent unknown remote nodes from being able to connect to you. If you'd
-like to pre-fund some accounts for easier testing, you can populate the `alloc` field with account
-configs:
-
-```json
-"alloc": {
-  "0x0000000000000000000000000000000000000001": {"balance": "111111111"},
-  "0x0000000000000000000000000000000000000002": {"balance": "222222222"}
-}
-```
-
-With the genesis state defined in the above JSON file, you'll need to initialize **every** Geth node
-with it prior to starting it up to ensure all blockchain parameters are correctly set:
-
-```
-$ geth init path/to/genesis.json
-```
-
-#### Creating the rendezvous point
-
-With all nodes that you want to run initialized to the desired genesis state, you'll need to start a
-bootstrap node that others can use to find each other in your network and/or over the internet. The
-clean way is to configure and run a dedicated bootnode:
-
-```
-$ bootnode --genkey=boot.key
-$ bootnode --nodekey=boot.key
-```
-
-With the bootnode online, it will display an [`enode` URL](https://github.com/ethereum/wiki/wiki/enode-url-format)
-that other nodes can use to connect to it and exchange peer information. Make sure to replace the
-displayed IP address information (most probably `[::]`) with your externally accessible IP to get the
-actual `enode` URL.
-
-*Note: You could also use a full fledged Geth node as a bootnode, but it's the less recommended way.*
-
-#### Starting up your member nodes
-
-With the bootnode operational and externally reachable (you can try `telnet <ip> <port>` to ensure
-it's indeed reachable), start every subsequent Geth node pointed to the bootnode for peer discovery
-via the `--bootnodes` flag. It will probably also be desirable to keep the data directory of your
-private network separated, so do also specify a custom `--datadir` flag.
-
-```
-$ geth --datadir=path/to/custom/data/folder --bootnodes=<bootnode-enode-url-from-above>
-```
-
-*Note: Since your network will be completely cut off from the main and test networks, you'll also
-need to configure a miner to process transactions and create new blocks for you.*
-
-#### Running a private miner
-
-Mining on the public Ethereum network is a complex task as it's only feasible using GPUs, requiring
-an OpenCL or CUDA enabled `ethminer` instance. For information on such a setup, please consult the
-[EtherMining subreddit](https://www.reddit.com/r/EtherMining/) and the [Genoil miner](https://github.com/Genoil/cpp-ethereum)
-repository.
-
-In a private network setting however, a single CPU miner instance is more than enough for practical
-purposes as it can produce a stable stream of blocks at the correct intervals without needing heavy
-resources (consider running on a single thread, no need for multiple ones either). To start a Geth
-instance for mining, run it with all your usual flags, extended by:
-
-```
-$ geth <usual-flags> --mine --minerthreads=1 --etherbase=0x0000000000000000000000000000000000000000
-```
-
-Which will start mining blocks and transactions on a single CPU thread, crediting all proceedings to
-the account specified by `--etherbase`. You can further tune the mining by changing the default gas
-limit blocks converge to (`--targetgaslimit`) and the price transactions are accepted at (`--gasprice`).
-
-## Contribution
-
-Thank you for considering to help out with the source code! We welcome contributions from
-anyone on the internet, and are grateful for even the smallest of fixes!
-
-If you'd like to contribute to go-ethereum, please fork, fix, commit and send a pull request
-for the maintainers to review and merge into the main code base. If you wish to submit more
-complex changes though, please check up with the core devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum)
-to ensure those changes are in line with the general philosophy of the project and/or get some
-early feedback which can make both your efforts much lighter as well as our review and merge
-procedures quick and simple.
-
-Please make sure your contributions adhere to our coding guidelines:
-
- * Code must adhere to the official Go [formatting](https://golang.org/doc/effective_go.html#formatting) guidelines (i.e. uses [gofmt](https://golang.org/cmd/gofmt/)).
- * Code must be documented adhering to the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
- * Pull requests need to be based on and opened against the `master` branch.
- * Commit messages should be prefixed with the package(s) they modify.
-   * E.g. "eth, rpc: make trace configs optional"
-
-Please see the [Developers' Guide](https://github.com/ethereum/go-ethereum/wiki/Developers'-Guide)
-for more details on configuring your environment, managing project dependencies and testing procedures.
+    What would you like to do? (default = stats)
+    1. Show network stats
+    2. Configure new genesis
+    3. Track new remote server
+    4. Deploy network components
+    > 2
+
+    Which consensus engine to use? (default = thunder)
+    1. Ethash - proof-of-work
+    2. Clique - proof-of-authority
+    3. Thunder - thundercore
+    > 3
+
+    Which accounts should be pre-funded? (advisable at least one)
+    > 0x8ddf4f3e475f5b5f10ec5bf3452f94830e9d2ce9
+
+    Specify your chain/network ID if you want an explicit one (default = random)
+    > 3606
+
+    What would you like to do? (default = stats)
+    1. Show network stats
+    2. Manage existing genesis
+    3. Track new remote server
+    4. Deploy network components
+    > 2
+
+    1. Modify existing fork rules
+    2. Export genesis configuration
+    3. Remove genesis configuration
+    > 2
+
+    Which file to save the genesis into? (default = ThunderLocal.json)
+    > thunder.json
+
+Then, you can initialize then start chain as described [above](#initchain)
 
 ## License
 
-The go-ethereum library (i.e. all code outside of the `cmd` directory) is licensed under the
-[GNU Lesser General Public License v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html), also
-included in our repository in the `COPYING.LESSER` file.
+  Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+  This file comprises an original work of authorship that may make use of, or
+  interface with another work licensed under a GNU or third party license, but
+  which is not otherwise based on said another work.
 
-The go-ethereum binaries (i.e. all code inside of the `cmd` directory) is licensed under the
-[GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html), also included
-in our repository in the `COPYING` file.
+  To the extent that portions of this file contains source code that is subject
+  to the terms of the GNU or third party license, the minimal corresponding source
+  code for those portions can be freely redistributed and/or modified under the
+  terms of the respective license, either of GNU Lesser General Public License version 3
+  or (at your option) any later version.
+
+  The remaining code for the ThunderCore™ network application is not a contribution
+  to be incorporated into said another work.  Rather, it is open source and licensed
+  from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+  original or modified work without a fee, subject to reciprocity and recipient’s
+  (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+  affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+  any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+  to not unfairly compete against or interfere with Thunder Token’s business or commercial
+  relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+  enforceability, title, or ownership (by Thunder Token) of any intellectual property
+  rights arising from or relating to the ThunderCore™ network application.  Further, you,
+  the recipient, agree to and must do the following: (1) give prominent notice and
+  attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+  original work and include any appropriate copyright, trademark, patent notices,
+  (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+  or, at your option, any later version) in its entirety or a link directing the user to
+  the same, (3) accompany the modified work with a prominent notice indicating that it
+  has been modified and that it was based off of the original work; and (4) convey or
+  otherwise make freely available the source code corresponding to the modified work
+  under the same conditions and restrictions on the exercise of rights granted or
+  affirmed under this license.
+
+  Your copying, reverse-engineering, debugging, modifying, or distributing the original
+  or modified work constitutes assent and agreement to these terms.  You may not use this
+  file in any way except in compliance with the terms of this license.
+
+  The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+  TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+  not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+  consequential damages (including, without limitation, procurement of substitute goods or
+  services, loss of use, data or profits or business interruption) however caused and under
+  any theory of liability, whether in contract, strict liability, or tort (including negligence)
+  or otherwise arising in any way out of the use of or inability to use the software, even if
+  advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+  even if deemed to fail of their essential purpose.  The software may only be distributed under
+  these terms and this disclaimer.
+
+  This license does not grant permission to use the trade names, trademarks, service marks, or
+  product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+  customary use in describing the origin of the work and reproducing the content of this file.
+
+  Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+  this TT license from time to time.
+
+  You should have received a copy of the specific GNU license along with this file,
+  the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+  <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.

--- a/README_ETH.md
+++ b/README_ETH.md
@@ -1,0 +1,311 @@
+## Go Ethereum
+
+Official golang implementation of the Ethereum protocol.
+
+[![API Reference](
+https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
+)](https://godoc.org/github.com/ethereum/go-ethereum)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ethereum/go-ethereum)](https://goreportcard.com/report/github.com/ethereum/go-ethereum)
+[![Travis](https://travis-ci.org/ethereum/go-ethereum.svg?branch=master)](https://travis-ci.org/ethereum/go-ethereum)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereum/go-ethereum?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+Automated builds are available for stable releases and the unstable master branch.
+Binary archives are published at https://geth.ethereum.org/downloads/.
+
+## Building the source
+
+For prerequisites and detailed build instructions please read the
+[Installation Instructions](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum)
+on the wiki.
+
+Building geth requires both a Go (version 1.7 or later) and a C compiler.
+You can install them using your favourite package manager.
+Once the dependencies are installed, run
+
+    make geth
+
+or, to build the full suite of utilities:
+
+    make all
+
+## Executables
+
+The go-ethereum project comes with several wrappers/executables found in the `cmd` directory.
+
+| Command    | Description |
+|:----------:|-------------|
+| **`geth`** | Our main Ethereum CLI client. It is the entry point into the Ethereum network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It can be used by other processes as a gateway into the Ethereum network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI Wiki page](https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options) for command line options. |
+| `abigen` | Source code generator to convert Ethereum contract definitions into easy to use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI) with expanded functionality if the contract bytecode is also available. However it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://github.com/ethereum/go-ethereum/wiki/Native-DApps:-Go-bindings-to-Ethereum-contracts) wiki page for details. |
+| `bootnode` | Stripped down version of our Ethereum client implementation that only takes part in the network node discovery protocol, but does not run any of the higher level application protocols. It can be used as a lightweight bootstrap node to aid in finding peers in private networks. |
+| `evm` | Developer utility version of the EVM (Ethereum Virtual Machine) that is capable of running bytecode snippets within a configurable environment and execution mode. Its purpose is to allow isolated, fine-grained debugging of EVM opcodes (e.g. `evm --code 60ff60ff --debug`). |
+| `gethrpctest` | Developer utility tool to support our [ethereum/rpc-test](https://github.com/ethereum/rpc-tests) test suite which validates baseline conformity to the [Ethereum JSON RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC) specs. Please see the [test suite's readme](https://github.com/ethereum/rpc-tests/blob/master/README.md) for details. |
+| `rlpdump` | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://github.com/ethereum/wiki/wiki/RLP)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`). |
+| `swarm`    | Swarm daemon and tools. This is the entrypoint for the Swarm network. `swarm --help` for command line options and subcommands. See [Swarm README](https://github.com/ethereum/go-ethereum/tree/master/swarm) for more information. |
+| `puppeth`    | a CLI wizard that aids in creating a new Ethereum network. |
+
+## Running geth
+
+Going through all the possible command line flags is out of scope here (please consult our
+[CLI Wiki page](https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options)), but we've
+enumerated a few common parameter combos to get you up to speed quickly on how you can run your
+own Geth instance.
+
+### Full node on the main Ethereum network
+
+By far the most common scenario is people wanting to simply interact with the Ethereum network:
+create accounts; transfer funds; deploy and interact with contracts. For this particular use-case
+the user doesn't care about years-old historical data, so we can fast-sync quickly to the current
+state of the network. To do so:
+
+```
+$ geth console
+```
+
+This command will:
+
+ * Start geth in fast sync mode (default, can be changed with the `--syncmode` flag), causing it to
+   download more data in exchange for avoiding processing the entire history of the Ethereum network,
+   which is very CPU intensive.
+ * Start up Geth's built-in interactive [JavaScript console](https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console),
+   (via the trailing `console` subcommand) through which you can invoke all official [`web3` methods](https://github.com/ethereum/wiki/wiki/JavaScript-API)
+   as well as Geth's own [management APIs](https://github.com/ethereum/go-ethereum/wiki/Management-APIs).
+   This tool is optional and if you leave it out you can always attach to an already running Geth instance
+   with `geth attach`.
+
+### Full node on the Ethereum test network
+
+Transitioning towards developers, if you'd like to play around with creating Ethereum contracts, you
+almost certainly would like to do that without any real money involved until you get the hang of the
+entire system. In other words, instead of attaching to the main network, you want to join the **test**
+network with your node, which is fully equivalent to the main network, but with play-Ether only.
+
+```
+$ geth --testnet console
+```
+
+The `console` subcommand have the exact same meaning as above and they are equally useful on the
+testnet too. Please see above for their explanations if you've skipped to here.
+
+Specifying the `--testnet` flag however will reconfigure your Geth instance a bit:
+
+ * Instead of using the default data directory (`~/.ethereum` on Linux for example), Geth will nest
+   itself one level deeper into a `testnet` subfolder (`~/.ethereum/testnet` on Linux). Note, on OSX
+   and Linux this also means that attaching to a running testnet node requires the use of a custom
+   endpoint since `geth attach` will try to attach to a production node endpoint by default. E.g.
+   `geth attach <datadir>/testnet/geth.ipc`. Windows users are not affected by this.
+ * Instead of connecting the main Ethereum network, the client will connect to the test network,
+   which uses different P2P bootnodes, different network IDs and genesis states.
+   
+*Note: Although there are some internal protective measures to prevent transactions from crossing
+over between the main network and test network, you should make sure to always use separate accounts
+for play-money and real-money. Unless you manually move accounts, Geth will by default correctly
+separate the two networks and will not make any accounts available between them.*
+
+### Full node on the Rinkeby test network
+
+The above test network is a cross client one based on the ethash proof-of-work consensus algorithm. As such, it has certain extra overhead and is more susceptible to reorganization attacks due to the network's low difficulty / security. Go Ethereum also supports connecting to a proof-of-authority based test network called [*Rinkeby*](https://www.rinkeby.io) (operated by members of the community). This network is lighter, more secure, but is only supported by go-ethereum.
+
+```
+$ geth --rinkeby console
+```
+
+### Configuration
+
+As an alternative to passing the numerous flags to the `geth` binary, you can also pass a configuration file via:
+
+```
+$ geth --config /path/to/your_config.toml
+```
+
+To get an idea how the file should look like you can use the `dumpconfig` subcommand to export your existing configuration:
+
+```
+$ geth --your-favourite-flags dumpconfig
+```
+
+*Note: This works only with geth v1.6.0 and above.*
+
+#### Docker quick start
+
+One of the quickest ways to get Ethereum up and running on your machine is by using Docker:
+
+```
+docker run -d --name ethereum-node -v /Users/alice/ethereum:/root \
+           -p 8545:8545 -p 30303:30303 \
+           ethereum/client-go
+```
+
+This will start geth in fast-sync mode with a DB memory allowance of 1GB just as the above command does.  It will also create a persistent volume in your home directory for saving your blockchain as well as map the default ports. There is also an `alpine` tag available for a slim version of the image.
+
+Do not forget `--rpcaddr 0.0.0.0`, if you want to access RPC from other containers and/or hosts. By default, `geth` binds to the local interface and RPC endpoints is not accessible from the outside.
+
+### Programatically interfacing Geth nodes
+
+As a developer, sooner rather than later you'll want to start interacting with Geth and the Ethereum
+network via your own programs and not manually through the console. To aid this, Geth has built-in
+support for a JSON-RPC based APIs ([standard APIs](https://github.com/ethereum/wiki/wiki/JSON-RPC) and
+[Geth specific APIs](https://github.com/ethereum/go-ethereum/wiki/Management-APIs)). These can be
+exposed via HTTP, WebSockets and IPC (unix sockets on unix based platforms, and named pipes on Windows).
+
+The IPC interface is enabled by default and exposes all the APIs supported by Geth, whereas the HTTP
+and WS interfaces need to manually be enabled and only expose a subset of APIs due to security reasons.
+These can be turned on/off and configured as you'd expect.
+
+HTTP based JSON-RPC API options:
+
+  * `--rpc` Enable the HTTP-RPC server
+  * `--rpcaddr` HTTP-RPC server listening interface (default: "localhost")
+  * `--rpcport` HTTP-RPC server listening port (default: 8545)
+  * `--rpcapi` API's offered over the HTTP-RPC interface (default: "eth,net,web3")
+  * `--rpccorsdomain` Comma separated list of domains from which to accept cross origin requests (browser enforced)
+  * `--ws` Enable the WS-RPC server
+  * `--wsaddr` WS-RPC server listening interface (default: "localhost")
+  * `--wsport` WS-RPC server listening port (default: 8546)
+  * `--wsapi` API's offered over the WS-RPC interface (default: "eth,net,web3")
+  * `--wsorigins` Origins from which to accept websockets requests
+  * `--ipcdisable` Disable the IPC-RPC server
+  * `--ipcapi` API's offered over the IPC-RPC interface (default: "admin,debug,eth,miner,net,personal,shh,txpool,web3")
+  * `--ipcpath` Filename for IPC socket/pipe within the datadir (explicit paths escape it)
+
+You'll need to use your own programming environments' capabilities (libraries, tools, etc) to connect
+via HTTP, WS or IPC to a Geth node configured with the above flags and you'll need to speak [JSON-RPC](http://www.jsonrpc.org/specification)
+on all transports. You can reuse the same connection for multiple requests!
+
+**Note: Please understand the security implications of opening up an HTTP/WS based transport before
+doing so! Hackers on the internet are actively trying to subvert Ethereum nodes with exposed APIs!
+Further, all browser tabs can access locally running webservers, so malicious webpages could try to
+subvert locally available APIs!**
+
+### Operating a private network
+
+Maintaining your own private network is more involved as a lot of configurations taken for granted in
+the official networks need to be manually set up.
+
+#### Defining the private genesis state
+
+First, you'll need to create the genesis state of your networks, which all nodes need to be aware of
+and agree upon. This consists of a small JSON file (e.g. call it `genesis.json`):
+
+```json
+{
+  "config": {
+        "chainId": 0,
+        "homesteadBlock": 0,
+        "eip155Block": 0,
+        "eip158Block": 0
+    },
+  "alloc"      : {},
+  "coinbase"   : "0x0000000000000000000000000000000000000000",
+  "difficulty" : "0x20000",
+  "extraData"  : "",
+  "gasLimit"   : "0x2fefd8",
+  "nonce"      : "0x0000000000000042",
+  "mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "timestamp"  : "0x00"
+}
+```
+
+The above fields should be fine for most purposes, although we'd recommend changing the `nonce` to
+some random value so you prevent unknown remote nodes from being able to connect to you. If you'd
+like to pre-fund some accounts for easier testing, you can populate the `alloc` field with account
+configs:
+
+```json
+"alloc": {
+  "0x0000000000000000000000000000000000000001": {"balance": "111111111"},
+  "0x0000000000000000000000000000000000000002": {"balance": "222222222"}
+}
+```
+
+With the genesis state defined in the above JSON file, you'll need to initialize **every** Geth node
+with it prior to starting it up to ensure all blockchain parameters are correctly set:
+
+```
+$ geth init path/to/genesis.json
+```
+
+#### Creating the rendezvous point
+
+With all nodes that you want to run initialized to the desired genesis state, you'll need to start a
+bootstrap node that others can use to find each other in your network and/or over the internet. The
+clean way is to configure and run a dedicated bootnode:
+
+```
+$ bootnode --genkey=boot.key
+$ bootnode --nodekey=boot.key
+```
+
+With the bootnode online, it will display an [`enode` URL](https://github.com/ethereum/wiki/wiki/enode-url-format)
+that other nodes can use to connect to it and exchange peer information. Make sure to replace the
+displayed IP address information (most probably `[::]`) with your externally accessible IP to get the
+actual `enode` URL.
+
+*Note: You could also use a full fledged Geth node as a bootnode, but it's the less recommended way.*
+
+#### Starting up your member nodes
+
+With the bootnode operational and externally reachable (you can try `telnet <ip> <port>` to ensure
+it's indeed reachable), start every subsequent Geth node pointed to the bootnode for peer discovery
+via the `--bootnodes` flag. It will probably also be desirable to keep the data directory of your
+private network separated, so do also specify a custom `--datadir` flag.
+
+```
+$ geth --datadir=path/to/custom/data/folder --bootnodes=<bootnode-enode-url-from-above>
+```
+
+*Note: Since your network will be completely cut off from the main and test networks, you'll also
+need to configure a miner to process transactions and create new blocks for you.*
+
+#### Running a private miner
+
+Mining on the public Ethereum network is a complex task as it's only feasible using GPUs, requiring
+an OpenCL or CUDA enabled `ethminer` instance. For information on such a setup, please consult the
+[EtherMining subreddit](https://www.reddit.com/r/EtherMining/) and the [Genoil miner](https://github.com/Genoil/cpp-ethereum)
+repository.
+
+In a private network setting however, a single CPU miner instance is more than enough for practical
+purposes as it can produce a stable stream of blocks at the correct intervals without needing heavy
+resources (consider running on a single thread, no need for multiple ones either). To start a Geth
+instance for mining, run it with all your usual flags, extended by:
+
+```
+$ geth <usual-flags> --mine --minerthreads=1 --etherbase=0x0000000000000000000000000000000000000000
+```
+
+Which will start mining blocks and transactions on a single CPU thread, crediting all proceedings to
+the account specified by `--etherbase`. You can further tune the mining by changing the default gas
+limit blocks converge to (`--targetgaslimit`) and the price transactions are accepted at (`--gasprice`).
+
+## Contribution
+
+Thank you for considering to help out with the source code! We welcome contributions from
+anyone on the internet, and are grateful for even the smallest of fixes!
+
+If you'd like to contribute to go-ethereum, please fork, fix, commit and send a pull request
+for the maintainers to review and merge into the main code base. If you wish to submit more
+complex changes though, please check up with the core devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum)
+to ensure those changes are in line with the general philosophy of the project and/or get some
+early feedback which can make both your efforts much lighter as well as our review and merge
+procedures quick and simple.
+
+Please make sure your contributions adhere to our coding guidelines:
+
+ * Code must adhere to the official Go [formatting](https://golang.org/doc/effective_go.html#formatting) guidelines (i.e. uses [gofmt](https://golang.org/cmd/gofmt/)).
+ * Code must be documented adhering to the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
+ * Pull requests need to be based on and opened against the `master` branch.
+ * Commit messages should be prefixed with the package(s) they modify.
+   * E.g. "eth, rpc: make trace configs optional"
+
+Please see the [Developers' Guide](https://github.com/ethereum/go-ethereum/wiki/Developers'-Guide)
+for more details on configuring your environment, managing project dependencies and testing procedures.
+
+## License
+
+The go-ethereum library (i.e. all code outside of the `cmd` directory) is licensed under the
+[GNU Lesser General Public License v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html), also
+included in our repository in the `COPYING.LESSER` file.
+
+The go-ethereum binaries (i.e. all code inside of the `cmd` directory) is licensed under the
+[GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html), also included
+in our repository in the `COPYING` file.

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -1,18 +1,62 @@
-// Copyright 2017 The go-ethereum Authors
-// This file is part of go-ethereum.
-//
-// go-ethereum is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// go-ethereum is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
 
 package main
 
@@ -49,9 +93,10 @@ func (w *wizard) makeGenesis() {
 	}
 	// Figure out which consensus engine to choose
 	fmt.Println()
-	fmt.Println("Which consensus engine to use? (default = clique)")
+	fmt.Println("Which consensus engine to use? (default = thunder)")
 	fmt.Println(" 1. Ethash - proof-of-work")
 	fmt.Println(" 2. Clique - proof-of-authority")
+	fmt.Println(" 3. Thunder - thundercore")
 
 	choice := w.read()
 	switch {
@@ -60,7 +105,7 @@ func (w *wizard) makeGenesis() {
 		genesis.Config.Ethash = new(params.EthashConfig)
 		genesis.ExtraData = make([]byte, 32)
 
-	case choice == "" || choice == "2":
+	case choice == "2":
 		// In the case of clique, configure the consensus parameters
 		genesis.Difficulty = big.NewInt(1)
 		genesis.Config.Clique = &params.CliqueConfig{
@@ -98,6 +143,10 @@ func (w *wizard) makeGenesis() {
 			copy(genesis.ExtraData[32+i*common.AddressLength:], signer[:])
 		}
 
+	case choice == "" || choice == "3":
+		genesis.Difficulty = big.NewInt(1)
+		genesis.GasLimit = 10000000
+		genesis.Config.Thunder = &params.ThunderConfig{}
 	default:
 		log.Crit("Invalid consensus engine choice", "choice", choice)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1,18 +1,62 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of go-ethereum.
-//
-// go-ethereum is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// go-ethereum is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
 
 // Package utils contains internal helper functions for go-ethereum commands.
 package utils
@@ -35,6 +79,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/thunder"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -1354,6 +1399,8 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	var engine consensus.Engine
 	if config.Clique != nil {
 		engine = clique.New(config.Clique, chainDb)
+	} else if config.Thunder != nil {
+		engine = thunder.New(config.Thunder)
 	} else {
 		engine = ethash.NewFaker()
 		if !ctx.GlobalBool(FakePoWFlag.Name) {

--- a/consensus/thunder/thunder.go
+++ b/consensus/thunder/thunder.go
@@ -1,0 +1,391 @@
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU Lesser General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
+
+package thunder
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const (
+	// TODO: set/change this to a better limit.
+	// Currently it is large since we don't know how this will play with fast path recovery.
+	allowedFutureBlockTime = 365 * 24 * 3600 * time.Second
+	// We are using fixed gas limit for test net. This limit is same as that in genesis.go
+	blockGasLimit = uint64(10000000)
+
+	blockInterval = 1 * time.Second
+)
+
+var (
+	zeroUncleHash = types.EmptyUncleHash
+	// Currently to zero
+	zeroCoinbaseAddress = common.Address{}
+	unityDifficulty     = big.NewInt(1)
+	// Used by ethhash for DAO header. Clique uses it for it's own thing.
+	// We don't need it in thunder.
+	zeroExtraData = make([]byte, 0)
+	// ethhash uses MixDigest for something related to PoW.
+	// clique consensus doesn't use it and checks it to be zero.
+	// So we likely don't need it at this point.
+	zeroMixDigest = common.Hash{}
+	// Nonce is zero since we are not using PoW algorithm.
+	zeroNonce = [8]byte{0, 0, 0, 0, 0, 0, 0, 0}
+
+	// Various error messages to mark blocks invalid. These should be private to
+	// prevent engine specific errors from being referenced in the remainder of the
+	// codebase, inherently breaking if the engine is swapped out. Please put common
+	// error types into the consensus package.
+	errUnknownBlock = errors.New("block number is nil")
+
+	errSealOperationOnGenesisBlock = errors.New(
+		"verifySeal/Seal operations on genesis block not permitted")
+
+	// If child block's timestamp < parent block's timestamp
+	errBackwardBlockTime = errors.New("block timestamp less than parent's timestamp")
+
+	// Errors for unused fields not set to zero/empty
+
+	errNonEmptyUncleHash = errors.New("non empty uncle hash")
+	errNonEmptyAddress   = errors.New("non empty coinbase address")
+	// Thunder PoS doesn't have difficulty as in PoW.
+	errNonZeroDifficulty = errors.New("non zero difficulty")
+	errNonEmptyExtra     = errors.New("non empty extra")
+	errNonEmptyMixDigest = errors.New("non-zero mix digest")
+	errNonZeroNonce      = errors.New("non-zero nonce")
+)
+
+// Thunder is the proof-of-stake consensus engine.
+type Thunder struct {
+	config *params.ThunderConfig // Consensus engine configuration parameters
+}
+
+// New creates a Thunder proof-of-stake consensus engine.
+func New(config *params.ThunderConfig) *Thunder {
+	return &Thunder{config: config}
+}
+
+//////////////////////////////////
+// consensus.Engine implementation
+//////////////////////////////////
+
+// Author implements consensus.Engine.
+func (thunder *Thunder) Author(header *types.Header) (common.Address, error) {
+	return zeroCoinbaseAddress, nil
+}
+
+// CalcDifficulty implements consensus.Engine
+// CalcDifficulty is used for difficulty adjustment in PoW algorithms. Not relevant in Thunder.
+func (thunder *Thunder) CalcDifficulty(chain consensus.ChainReader, time uint64,
+	parent *types.Header) *big.Int {
+	return big.NewInt(0)
+
+}
+
+// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
+// method returns a quit channel to abort the operations and a results channel to
+// retrieve the async verifications (the order is that of the input slice).
+func (thunder *Thunder) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header,
+	seals []bool) (chan<- struct{}, <-chan error) {
+	abort := make(chan struct{})
+	results := make(chan error, len(headers))
+
+	go func() {
+		for i, header := range headers {
+			err := thunder.VerifyHeader(chain, header, seals[i])
+
+			select {
+			case <-abort:
+				return
+			case results <- err:
+			}
+		}
+	}()
+	return abort, results
+}
+
+func verifyHeaderUnusedFieldsAreZero(header *types.Header) error {
+	// Ensure that the block doesn't contain any uncles
+	if header.UncleHash != zeroUncleHash {
+		return errNonEmptyUncleHash
+	}
+	if header.Coinbase != zeroCoinbaseAddress {
+		return errNonEmptyAddress
+	}
+	// Ensure that the block's difficulty is zero.
+	if header.Difficulty.Cmp(unityDifficulty) != 0 {
+		return errNonZeroDifficulty
+	}
+	if bytes.Compare(header.Extra, zeroExtraData) != 0 {
+		return errNonEmptyExtra
+	}
+	// Ensure that the mix digest is zero. Provisioned for fork protection in Ethereum.
+	if header.MixDigest != zeroMixDigest {
+		return errNonEmptyMixDigest
+	}
+	if !bytes.Equal(header.Nonce[:], zeroNonce[:]) {
+		return errNonZeroNonce
+	}
+	return nil
+}
+
+// VerifyHeader checks whether a header conforms to the consensus rules.
+func (thunder *Thunder) VerifyHeader(chain consensus.ChainReader, header *types.Header,
+	seal bool) error {
+	if header.Number == nil {
+		return errUnknownBlock
+	}
+	// If the block is already in local chain, no need to verify again.
+	number := header.Number.Uint64()
+	if number == 0 {
+		return nil
+	}
+	if chain.GetHeader(header.Hash(), number) != nil {
+		return nil
+	}
+	parent := chain.GetHeader(header.ParentHash, number-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+	// Verify that the block number is parent's +1
+	if diff := new(big.Int).Sub(header.Number, parent.Number); diff.Cmp(big.NewInt(1)) != 0 {
+		return consensus.ErrInvalidNumber
+	}
+	// Don't waste time checking blocks from the future
+	if header.Time.Cmp(big.NewInt(time.Now().Add(allowedFutureBlockTime).Unix())) > 0 {
+		return consensus.ErrFutureBlock
+	}
+	if header.Time.Cmp(parent.Time) < 0 {
+		return errBackwardBlockTime
+	}
+	if err := verifyHeaderUnusedFieldsAreZero(header); err != nil {
+		return err
+	}
+	if header.GasLimit != blockGasLimit {
+		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit,
+			blockGasLimit)
+	}
+	// Verify that the gasUsed is <= gasLimit
+	if header.GasUsed > header.GasLimit {
+		return fmt.Errorf("invalid gasUsed: have %d, gasLimit %d", header.GasUsed,
+			header.GasLimit)
+	}
+	// Verify the engine specific seal securing the block
+	if seal {
+		if err := thunder.VerifySeal(chain, header); err != nil {
+			return err
+		}
+	}
+	// Note: Removed validations regarding hard-forks.
+	// We may want to put add a check here when we plan for forks.
+	return nil
+}
+
+// VerifyUncles implements consensus.Engine, always returning an error for any
+// uncles as this consensus mechanism doesn't permit uncles.
+func (thunder *Thunder) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
+	if len(block.Uncles()) > 0 {
+		return errors.New("uncles not allowed")
+	}
+	return nil
+}
+
+// VerifySeal implements consensus.Engine.
+// In thunder protocol, we don't store signed proposals in the block.
+func (thunder *Thunder) VerifySeal(chain consensus.ChainReader, header *types.Header) error {
+	// Verifying the genesis block is not supported
+	number := header.Number.Uint64()
+	if number == 0 {
+		return errSealOperationOnGenesisBlock
+	}
+	return nil
+}
+
+// All header fields which are not relevant in Thunder protocol are set to predefined zero values.
+func setHeaderUnusedFieldsToZero(header *types.Header) {
+	header.UncleHash = zeroUncleHash
+	header.Coinbase = zeroCoinbaseAddress
+	header.Difficulty = unityDifficulty
+	header.Extra = zeroExtraData
+	header.MixDigest = zeroMixDigest
+	header.Nonce = zeroNonce
+}
+
+// Prepare implements consensus.Engine, preparing all the consensus fields of the
+// header for running the transactions on top.
+func (thunder *Thunder) Prepare(chain consensus.ChainReader, header *types.Header) error {
+	setHeaderUnusedFieldsToZero(header)
+	number := header.Number.Uint64()
+
+	// Ensure the timestamp has the correct delay
+	parent := chain.GetHeader(header.ParentHash, number-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+	header.Time = new(big.Int).Add(parent.Time, new(big.Int).SetUint64(0))
+	if header.Time.Int64() < time.Now().Unix() {
+		header.Time = big.NewInt(time.Now().Unix())
+	}
+	header.GasLimit = blockGasLimit
+	return nil
+}
+
+// Finalize implements consensus.Engine, ensuring no uncles are set, nor block
+// rewards given, and returns the final block.
+func (thunder *Thunder) Finalize(chain consensus.ChainReader, header *types.Header,
+	state *state.StateDB, txs []*types.Transaction, uncles []*types.Header,
+	receipts []*types.Receipt) (*types.Block, error) {
+	// No block rewards in Thunder, so the state remains as is and uncles are dropped
+	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
+	setHeaderUnusedFieldsToZero(header)
+
+	// Assemble and return the final block for sealing
+	return types.NewBlock(header, txs, nil, receipts), nil
+}
+
+// Seal implements consensus.Engine.
+func (thunder *Thunder) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block,
+	stop <-chan struct{}) error {
+	header := block.Header()
+
+	// Sealing the genesis block is not supported
+	number := header.Number.Uint64()
+	if number == 0 {
+		return errSealOperationOnGenesisBlock
+	}
+
+	go func() {
+		select {
+		case <-stop:
+			return
+		case <-time.After(blockInterval):
+		}
+
+		select {
+		case results <- block.WithSeal(header):
+		default:
+			log.Warn("Sealing result is not read by miner", "sealhash", thunder.SealHash(header))
+		}
+	}()
+	return nil
+}
+
+// Close implements consensus.Engine. It's a noop for Thunder as there is are no background threads.
+func (thunder *Thunder) Close() error {
+	return nil
+}
+
+// SealHash returns the hash of a block prior to it being sealed.
+func (thunder *Thunder) SealHash(header *types.Header) (hash common.Hash) {
+	hasher := sha3.NewKeccak256()
+
+	rlp.Encode(hasher, []interface{}{
+		header.ParentHash,
+		header.UncleHash,
+		header.Coinbase,
+		header.Root,
+		header.TxHash,
+		header.ReceiptHash,
+		header.Bloom,
+		header.Difficulty,
+		header.Number,
+		header.GasLimit,
+		header.GasUsed,
+		header.Time,
+		header.Extra,
+	})
+	hasher.Sum(hash[:0])
+	return hash
+}
+
+type API struct {
+	chain   consensus.ChainReader
+	thunder *Thunder
+}
+
+// GetBlockInterval retrieves block interval.
+func (api *API) GetBlockInterval() float64 {
+	return blockInterval.Seconds()
+}
+
+// APIs implements consensus.Engine, returning the user facing RPC API to allow
+// controlling the signer voting.
+func (thunder *Thunder) APIs(chain consensus.ChainReader) []rpc.API {
+	return []rpc.API{{
+		Namespace: "thunder",
+		Version:   "0.1",
+		Service:   &API{chain: chain, thunder: thunder},
+		Public:    false,
+	}}
+}

--- a/consensus/thunder/thunder_test.go
+++ b/consensus/thunder/thunder_test.go
@@ -1,0 +1,239 @@
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU Lesser General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
+
+package thunder
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthor(t *testing.T) {
+	assert := assert.New(t)
+
+	thunder := New(new(params.ThunderConfig))
+
+	coinbase, err := thunder.Author(nil)
+
+	assert.Equal(coinbase, zeroCoinbaseAddress, "error")
+	assert.Equal(err, nil, "error")
+}
+
+func TestCalcDifficulty(t *testing.T) {
+	assert := assert.New(t)
+
+	var difficulty *big.Int
+
+	thunder := New(new(params.ThunderConfig))
+
+	difficulty = thunder.CalcDifficulty(nil, 0, nil)
+
+	assert.Equal(difficulty.Int64(), int64(0), "error")
+}
+
+func makeThunderTestChain() *core.BlockChain {
+
+	var (
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		db      = ethdb.NewMemDatabase()
+	)
+
+	gspec := &core.Genesis{
+		Config:   params.TestThunderChainConfig,
+		Alloc:    core.GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
+		GasLimit: blockGasLimit,
+	}
+	genesis := gspec.MustCommit(db)
+
+	blockchain, _ := core.NewBlockChain(db, nil, gspec.Config, New(new(params.ThunderConfig)), vm.Config{})
+
+	blocks := make(types.Blocks, 1)
+	blocks[0] = genesis
+
+	blockchain.InsertChain(blocks)
+
+	return blockchain
+}
+
+func makeNewHeader(blockchain *core.BlockChain) *types.Header {
+
+	currBlock := blockchain.CurrentBlock()
+	header := &types.Header{
+		Number:     new(big.Int).Add(currBlock.Number(), common.Big1),
+		ParentHash: currBlock.Hash(),
+	}
+
+	return header
+}
+
+func TestThunderPrepare(t *testing.T) {
+
+	assert := assert.New(t)
+
+	blockchain := makeThunderTestChain()
+	header := makeNewHeader(blockchain)
+
+	thunder := New(new(params.ThunderConfig))
+	err := thunder.Prepare(blockchain, header)
+	assert.Equal(err, nil)
+	assert.Equal(header.UncleHash, zeroUncleHash)
+	assert.Equal(header.Coinbase, zeroCoinbaseAddress)
+	assert.Equal(header.Difficulty, unityDifficulty)
+	assert.Equal(header.Extra, zeroExtraData)
+	assert.Equal(header.MixDigest, zeroMixDigest)
+	assert.Equal(header.Nonce, types.BlockNonce{0, 0, 0, 0, 0, 0, 0, 0})
+	assert.Equal(header.GasLimit, blockGasLimit)
+}
+
+func TestThunderFinalize(t *testing.T) {
+
+	assert := assert.New(t)
+
+	blockchain := makeThunderTestChain()
+	header := makeNewHeader(blockchain)
+
+	thunder := New(new(params.ThunderConfig))
+	db := ethdb.NewMemDatabase()
+	state, _ := state.New(common.Hash{}, state.NewDatabase(db))
+
+	block, err := thunder.Finalize(blockchain, header, state, nil, nil, nil)
+	assert.Equal(err, nil)
+	assert.Equal(block.UncleHash(), zeroUncleHash)
+	assert.Equal(block.Coinbase(), zeroCoinbaseAddress)
+	assert.Equal(block.Difficulty(), unityDifficulty)
+	assert.Equal(block.Extra(), zeroExtraData)
+	assert.Equal(block.MixDigest(), zeroMixDigest)
+	assert.Equal(block.Nonce(), uint64(0))
+
+}
+
+func TestVerifyHeader(t *testing.T) {
+
+	assert := assert.New(t)
+
+	blockchain := makeThunderTestChain()
+	header := makeNewHeader(blockchain)
+	number := header.Number
+
+	thunder := New(new(params.ThunderConfig))
+	thunder.Prepare(blockchain, header)
+
+	err := thunder.VerifyHeader(blockchain, header, false)
+	assert.Equal(err, nil)
+
+	err = thunder.VerifyHeader(blockchain, header, true)
+	assert.Equal(err, nil)
+
+	header.Number = nil
+	assert.Equal(thunder.VerifyHeader(blockchain, header, false), errUnknownBlock)
+	header.Number = number
+
+	header.Number = big.NewInt(100)
+	assert.Equal(thunder.VerifyHeader(blockchain, header, false), consensus.ErrInvalidNumber)
+	header.Number = number
+
+	header.GasLimit = blockGasLimit + 1
+	assert.Errorf(thunder.VerifyHeader(blockchain, header, false),
+		fmt.Sprintf("invalid gasLimit: have %v, max %v", header.GasLimit, blockGasLimit))
+	header.GasLimit = blockGasLimit
+
+	header.GasUsed = blockGasLimit + 1
+	assert.Errorf(thunder.VerifyHeader(blockchain, header, false),
+		fmt.Sprintf("invalid gasUsed: have %d, gasLimit %d", header.GasUsed, header.GasLimit))
+}
+
+func TestSeal(t *testing.T) {
+
+	assert := assert.New(t)
+
+	resultsCh := make(chan *types.Block)
+
+	blockchain := makeThunderTestChain()
+	header := makeNewHeader(blockchain)
+
+	thunder := New(new(params.ThunderConfig))
+	thunder.Prepare(blockchain, header)
+
+	block := types.NewBlock(header, nil, nil, nil)
+
+	start := time.Now()
+	err := thunder.Seal(blockchain, block, resultsCh, make(chan struct{}))
+	assert.Equal(err, nil)
+
+	<-resultsCh
+
+	// Block interval is 1 second
+	elapsed := time.Since(start)
+	assert.True(elapsed.Seconds() >= blockInterval.Seconds())
+}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -1,18 +1,62 @@
-// Copyright 2014 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU Lesser General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
 
 package core
 
@@ -337,8 +381,7 @@ func DefaultRinkebyGenesisBlock() *Genesis {
 // be seeded with the
 func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 	// Override the default period to the user requested one
-	config := *params.AllCliqueProtocolChanges
-	config.Clique.Period = period
+	config := *params.AllThunderProtocolChanges
 
 	// Assemble and return the genesis with the precompiles and faucet pre-funded
 	return &Genesis{

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1,18 +1,62 @@
-// Copyright 2014 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU Lesser General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
 
 // Package eth implements the Ethereum protocol.
 package eth
@@ -31,6 +75,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/thunder"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -220,6 +265,9 @@ func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig *params.ChainCo
 	// If proof-of-authority is requested, set it up
 	if chainConfig.Clique != nil {
 		return clique.New(chainConfig.Clique, db)
+	} else if chainConfig.Thunder != nil {
+		// Set up Thunder Consensus Engine
+		return thunder.New(chainConfig.Thunder)
 	}
 	// Otherwise assume proof-of-work
 	switch config.PowMode {

--- a/params/config.go
+++ b/params/config.go
@@ -1,18 +1,62 @@
-// Copyright 2016 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2018 Thunder Token Inc., The ThunderCore™ Authors
+// This file comprises an original work of authorship that may make use of, or
+// interface with another work licensed under a GNU or third party license, but
+// which is not otherwise based on said another work.
+
+// To the extent that portions of this file contains source code that is subject
+// to the terms of the GNU or third party license, the minimal corresponding source
+// code for those portions can be freely redistributed and/or modified under the
+// terms of the respective license, either of GNU Lesser General Public License version 3
+// or (at your option) any later version.
+
+// The remaining code for the ThunderCore™ network application is not a contribution
+// to be incorporated into said another work.  Rather, it is open source and licensed
+// from Thunder Token Inc. to you, the recipient, to copy, modify and distribute the
+// original or modified work without a fee, subject to reciprocity and recipient’s
+// (i) promise and covenant not to sue Thunder Token Inc., its assigns, successors,
+// affiliates and subsidiaries (hereinafter “Thunder Token”) on claims arising from
+// any of their use of recipient’s code, if any; (ii) promise and ongoing commitment
+// to not unfairly compete against or interfere with Thunder Token’s business or commercial
+// relationships; and (iii) promise and ongoing commitment to not challenge the validity,
+// enforceability, title, or ownership (by Thunder Token) of any intellectual property
+// rights arising from or relating to the ThunderCore™ network application.  Further, you,
+// the recipient, agree to and must do the following: (1) give prominent notice and
+// attribution to Thunder Token Inc. and the ThunderCore™ Authors for their work on the
+// original work and include any appropriate copyright, trademark, patent notices,
+// (2) accompany the original or modified work with a copy of this notice (TT license v1.0
+// or, at your option, any later version) in its entirety or a link directing the user to
+// the same, (3) accompany the modified work with a prominent notice indicating that it
+// has been modified and that it was based off of the original work; and (4) convey or
+// otherwise make freely available the source code corresponding to the modified work
+// under the same conditions and restrictions on the exercise of rights granted or
+// affirmed under this license.
+
+// Your copying, reverse-engineering, debugging, modifying, or distributing the original
+// or modified work constitutes assent and agreement to these terms.  You may not use this
+// file in any way except in compliance with the terms of this license.
+
+// The code is distributed AS-IS in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE or
+// TITLE or of non-infringement.  Thunder Token Inc. and any contributors to the software shall
+// not be liable for any direct, indirect, incidental, special, punitive, exemplary, or
+// consequential damages (including, without limitation, procurement of substitute goods or
+// services, loss of use, data or profits or business interruption) however caused and under
+// any theory of liability, whether in contract, strict liability, or tort (including negligence)
+// or otherwise arising in any way out of the use of or inability to use the software, even if
+// advised of the possibility of such damage.  The foregoing limitations of liability shall apply
+// even if deemed to fail of their essential purpose.  The software may only be distributed under
+// these terms and this disclaimer.
+
+// This license does not grant permission to use the trade names, trademarks, service marks, or
+// product names of ThunderCore™ or of Thunder Token Inc., except as required for reasonable and
+// customary use in describing the origin of the work and reproducing the content of this file.
+
+// Thunder Token Inc. and The ThunderCore™ Authors may publish revised and/or new versions of
+// this TT license from time to time.
+
+// You should have received a copy of the specific GNU license along with this file,
+// the ThunderCore™ library, or the go-ethereum library.  If not, then see, e.g.,
+// <https://www.gnu.org/licenses/lgpl-3.0.en.html> and/or <http://www.gnu.org/licenses/>.
 
 package params
 
@@ -84,17 +128,24 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil}
-	TestRules       = TestChainConfig.Rules(new(big.Int))
+	// AllThunderProtocolChanges provides a local chain config under ThunderCore protocol.
+	AllThunderProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &ThunderConfig{}}
+
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
+
+	// TestThunderChainConfig is for testing purpose
+	TestThunderChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(ThunderConfig)}
+
+	TestRules = TestChainConfig.Rules(new(big.Int))
 )
 
 // ChainConfig is the core config which determines the blockchain settings.
@@ -121,8 +172,9 @@ type ChainConfig struct {
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
-	Ethash *EthashConfig `json:"ethash,omitempty"`
-	Clique *CliqueConfig `json:"clique,omitempty"`
+	Ethash  *EthashConfig  `json:"ethash,omitempty"`
+	Clique  *CliqueConfig  `json:"clique,omitempty"`
+	Thunder *ThunderConfig `json:"thunder,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -144,6 +196,15 @@ func (c *CliqueConfig) String() string {
 	return "clique"
 }
 
+// ThunderConfig is the consensus engine config placeholder for Thunder chain
+type ThunderConfig struct {
+}
+
+// String implements the stringer interface, returning the consensus engine details.
+func (c *ThunderConfig) String() string {
+	return "thunder"
+}
+
 // String implements the fmt.Stringer interface.
 func (c *ChainConfig) String() string {
 	var engine interface{}
@@ -152,6 +213,8 @@ func (c *ChainConfig) String() string {
 		engine = c.Ethash
 	case c.Clique != nil:
 		engine = c.Clique
+	case c.Thunder != nil:
+		engine = c.Thunder
 	default:
 		engine = "unknown"
 	}


### PR DESCRIPTION
  This is the first commit to provide a way in Geth to generate
  blocks with Thunder specific header. Users can either create
  genesis json file with an empty thunder block or use puppeth
  to choose generating that attribute. When the local chain starts, it will
  choose to use Thunder consensus engine if it sees thunder in
  genesis json config file.